### PR TITLE
313 Add missing modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
 
 RUN apt-get update && \
     apt-get -y upgrade && \
-    apt-get install -y curl && \
+    apt-get install -y curl libfreetype6 libfontconfig1 && \
     rm -rf /var/lib/apt/lists/*
 
 ENV TZ=Europe/London


### PR DESCRIPTION
We're seeing this in the logs: `java.lang.UnsatisfiedLinkError: /usr/local/openjdk-16/lib/libfontmanager.so: libfreetype.so.6: cannot open shared object file: No such file or directory`
Googling around it looks like we're missing a couple of modules from the JVM.