### PR TITLE
313 Add verify barcode endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertransactionsapi/config/AuthAwareTokenConverter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertransactionsapi/config/AuthAwareTokenConverter.kt
@@ -44,7 +44,7 @@ class AuthAwareAuthenticationToken(
   private val aPrincipal: String,
   authorities: Collection<GrantedAuthority>
 ) : JwtAuthenticationToken(jwt, authorities) {
-  override fun getPrincipal(): Any {
+  override fun getPrincipal(): String {
     return aPrincipal
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertransactionsapi/config/SecurityUserContext.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertransactionsapi/config/SecurityUserContext.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.prisonertransactionsapi.config
+
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+
+@Component
+class SecurityUserContext {
+  val authentication: AuthAwareAuthenticationToken?
+    get() = with(SecurityContextHolder.getContext().authentication) {
+      when (this) {
+        is AuthAwareAuthenticationToken -> this
+        else -> null
+      }
+    }
+
+  val principal: String
+    get() {
+      return if (authentication?.principal != null) {
+        authentication?.principal!!
+      } else {
+        "anonymous"
+      }
+    }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertransactionsapi/jpa/BarcodeEventRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertransactionsapi/jpa/BarcodeEventRepository.kt
@@ -5,6 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
 import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
 import javax.persistence.Id
@@ -16,6 +18,7 @@ import javax.validation.constraints.NotNull
 @Repository
 interface BarcodeEventRepository : JpaRepository<BarcodeEvent, Long> {
   fun findByBarcode(barcode: Barcode): List<BarcodeEvent>
+  fun findByBarcodeAndStatus(barcode: Barcode, status: BarcodeStatus): List<BarcodeEvent>
 }
 
 @Entity
@@ -36,6 +39,7 @@ data class BarcodeEvent(
   @NotNull
   val prisonerId: String,
   @NotNull
+  @Enumerated(EnumType.STRING)
   val status: BarcodeStatus = BarcodeStatus.CREATED,
   @NotNull
   val dateTime: LocalDateTime = LocalDateTime.now(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertransactionsapi/service/BarcodeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonertransactionsapi/service/BarcodeService.kt
@@ -1,17 +1,21 @@
 package uk.gov.justice.digital.hmpps.prisonertransactionsapi.service
 
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.prisonertransactionsapi.config.SecurityUserContext
 import uk.gov.justice.digital.hmpps.prisonertransactionsapi.jpa.Barcode
 import uk.gov.justice.digital.hmpps.prisonertransactionsapi.jpa.BarcodeEvent
 import uk.gov.justice.digital.hmpps.prisonertransactionsapi.jpa.BarcodeEventRepository
 import uk.gov.justice.digital.hmpps.prisonertransactionsapi.jpa.BarcodeRepository
+import uk.gov.justice.digital.hmpps.prisonertransactionsapi.jpa.BarcodeStatus
 import java.awt.image.BufferedImage
+import javax.persistence.EntityNotFoundException
 
 @Service
 class BarcodeService(
   private val barcodeRepository: BarcodeRepository,
   private val barcodeEventRepository: BarcodeEventRepository,
   private val barcodeGeneratorService: BarcodeGeneratorService,
+  private val securityUserContext: SecurityUserContext,
 ) {
 
   fun createBarcode(userId: String, prisonerId: String): String =
@@ -35,4 +39,44 @@ class BarcodeService(
   }
 
   fun generateBarcodeImage(barcode: String): BufferedImage = barcodeGeneratorService.generateBarcodeImage(barcode)
+
+  fun verifyBarcode(code: String) {
+    barcodeRepository.findById(code).toNullable()
+      ?.takeIf { barcode -> barcodeEventRepository.findByBarcodeAndStatus(barcode, BarcodeStatus.SCANNED).isEmpty() }
+      ?.also { barcode -> createScannedEventFromCreatedEvent(barcode) }
+      ?: also {
+        createScannedEventForInvalidBarcode(code)
+        throw EntityNotFoundException("The barcode is invalid")
+      }
+  }
+
+  private fun createScannedEventFromCreatedEvent(barcode: Barcode) {
+    barcodeEventRepository.findByBarcodeAndStatus(barcode, BarcodeStatus.CREATED).firstOrNull()
+      ?.also { createdEvent ->
+        barcodeEventRepository.save(
+          BarcodeEvent(
+            barcode = barcode,
+            userId = securityUserContext.principal,
+            status = BarcodeStatus.SCANNED,
+            prisonerId = createdEvent.prisonerId,
+            prison = createdEvent.prison,
+          )
+        )
+      }
+  }
+
+  private fun createScannedEventForInvalidBarcode(code: String) {
+    barcodeRepository.findById(code).orElseGet { barcodeRepository.save(Barcode(code = code)) }
+      .also { barcode ->
+        barcodeEventRepository.save(
+          BarcodeEvent(
+            barcode = barcode,
+            userId = securityUserContext.principal,
+            status = BarcodeStatus.SCANNED,
+            prison = "n/a",
+            prisonerId = "n/a"
+          )
+        )
+      }
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertransactionsapi/integration/BarcodeResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertransactionsapi/integration/BarcodeResourceTest.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.prisonertransactionsapi.integration
+
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+
+class BarcodeResourceTest : IntegrationTestBase() {
+
+  @Test
+  fun `ok for a valid barcode`() {
+    val barcode = barcodeService.createBarcode("some_user", "a_prison")
+
+    webTestClient.post().uri("""/barcode/$barcode""")
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation())
+      .exchange()
+      .expectStatus().isOk
+  }
+
+  @Test
+  fun `not found for an invalid barcode`() {
+    webTestClient.post().uri("""/barcode/unknown""")
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation())
+      .exchange()
+      .expectStatus().isNotFound
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertransactionsapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonertransactionsapi/integration/IntegrationTestBase.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.prisonertransactionsapi.email.EmailSender
 import uk.gov.justice.digital.hmpps.prisonertransactionsapi.jpa.BarcodeEventRepository
 import uk.gov.justice.digital.hmpps.prisonertransactionsapi.jpa.BarcodeRepository
 import uk.gov.justice.digital.hmpps.prisonertransactionsapi.service.BarcodeGeneratorService
+import uk.gov.justice.digital.hmpps.prisonertransactionsapi.service.BarcodeService
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("test")
@@ -45,6 +46,9 @@ abstract class IntegrationTestBase {
 
   @Autowired
   protected lateinit var barcodeEventRepository: BarcodeEventRepository
+
+  @Autowired
+  protected lateinit var barcodeService: BarcodeService
 
   @AfterEach
   fun `clear database`() {


### PR DESCRIPTION
* Add new endpoint to verify a barcode
* If previously created by us and not already scanned then returns ok
* Otherwise returns not found
* Save unrecognised barcodes so they cannot be accidentally generated in the future